### PR TITLE
커뮤니티 리스트 조회시 seq, 댓글 수 속성 추가.

### DIFF
--- a/src/main/java/com/example/finalproject/domain/post/dto/PostDto.java
+++ b/src/main/java/com/example/finalproject/domain/post/dto/PostDto.java
@@ -1,10 +1,7 @@
 package com.example.finalproject.domain.post.dto;
 
 import com.example.finalproject.domain.post.entity.Post;
-import com.example.finalproject.domain.post.entity.PostCategories;
-import com.example.finalproject.domain.post.entity.PostTypes;
 import com.example.finalproject.domain.user.dto.UserDto;
-import com.example.finalproject.domain.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -34,12 +31,14 @@ public class PostDto {
 
     private Integer viewCount;
 
+    private Integer commentCount;
+
     private Timestamp registeredAt;
 
     private Timestamp updatedAt;
 
-    public static PostDto of(Integer seq, UserDto userDto, String postCategory, String postType, String title, String contents, Integer viewCount, Timestamp registeredAt, Timestamp updatedAt) {
-        return new PostDto(seq, userDto, postCategory, postType, title, contents, viewCount, registeredAt, updatedAt);
+    public static PostDto of(Integer seq, UserDto userDto, String postCategory, String postType, String title, String contents, Integer viewCount, Integer commentCount, Timestamp registeredAt, Timestamp updatedAt) {
+        return new PostDto(seq, userDto, postCategory, postType, title, contents, viewCount, commentCount, registeredAt, updatedAt);
     }
 
     public static PostDto from(Post post) {
@@ -51,6 +50,7 @@ public class PostDto {
                 post.getTitle(),
                 post.getContents(),
                 post.getViewCount(),
+                post.getComments().size(),
                 post.getRegisteredAt(),
                 post.getUpdatedAt()
         );

--- a/src/main/java/com/example/finalproject/domain/post/dto/response/PostListResponse.java
+++ b/src/main/java/com/example/finalproject/domain/post/dto/response/PostListResponse.java
@@ -14,15 +14,17 @@ import lombok.NoArgsConstructor;
 @JsonNaming(value = PropertyNamingStrategies.LowerCamelCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostListResponse {
+    private Integer seq;
     private String postType;
     private String title;
     private String contents;
     private String username;
     private String registeredAt;
     private Integer viewCount;
+    private Integer commentCount;
 
-    public static PostListResponse of(String postType, String title, String contents, String username, String registeredAt, Integer viewCount) {
-        return new PostListResponse(postType, title, contents, username, registeredAt, viewCount);
+    public static PostListResponse of(Integer seq, String postType, String title, String contents, String username, String registeredAt, Integer viewCount, Integer commentCount) {
+        return new PostListResponse(seq, postType, title, contents, username, registeredAt, viewCount, commentCount);
     }
 
     public static PostListResponse from(PostDto postDto) {
@@ -30,12 +32,14 @@ public class PostListResponse {
         String registeredDate = split[0];
 
         return PostListResponse.of(
+                postDto.getSeq(),
                 postDto.getPostType(),
                 postDto.getTitle(),
                 postDto.getContents(),
                 postDto.getUserDto().getName(),
                 registeredDate,
-                postDto.getViewCount()
+                postDto.getViewCount(),
+                postDto.getCommentCount()
         );
     }
 }


### PR DESCRIPTION
* 커뮤니티 리스트 전체 조회 시, 게시글의 seq 값이 존재하지 않았어서 추가.
* 댓글 수 속성또한 전체조회 시 보여줘야해서 commentCount 속성 추가.